### PR TITLE
Enable to set Furl timeout option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Net::OpenStack::Swift - Perl Bindings for the OpenStack Object Storage API, know
         password       => 'password',
         tenant_name    => 'project_id',
         # auth_version => '2.0', # by default
+        # timeout      => 10, # request timeout. default.
     );
 
     my ($storage_url, $token) = $sw->get_auth();
@@ -221,4 +222,4 @@ it under the same terms as Perl itself.
 
 # AUTHOR
 
-masakyst <masakyst.public@gmail.com>
+masakyst &lt;masakyst.public@gmail.com>

--- a/README.md
+++ b/README.md
@@ -222,4 +222,4 @@ it under the same terms as Perl itself.
 
 # AUTHOR
 
-masakyst &lt;masakyst.public@gmail.com>
+masakyst <masakyst.public@gmail.com>

--- a/lib/Net/OpenStack/Swift.pm
+++ b/lib/Net/OpenStack/Swift.pm
@@ -17,12 +17,14 @@ has password     => (is => 'rw', required => 1);
 has tenant_name  => (is => 'rw');
 has storage_url  => (is => 'rw');
 has token        => (is => 'rw');
+has timeout      => (is => 'rw', default => 10);
 has agent => (
     is      => 'rw',
     lazy    => 1,
     default => sub {
         my $self = shift;
         my $agent = Furl->new(
+	    timeout => $self->timeout
             #agent    => "Mozilla/5.0",
         );
         return $agent;


### PR DESCRIPTION
Hello.

This PR enables to set Furl timeout option when create Net::OpenStack::Swift like below

```
my $sw = Net::OpenStack::Swift->new(
    ...,
    ...,
    timeout => 20
    );

```