### PR TITLE
add option to set the region

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Net::OpenStack::Swift - Perl Bindings for the OpenStack Object Storage API, know
         user           => 'userid',
         password       => 'password',
         tenant_name    => 'project_id',
+        region         => 'REGION',
         # auth_version => '2.0', # by default
         # agent_options => +{
         #    timeout    => 10,

--- a/lib/Net/OpenStack/Swift.pm
+++ b/lib/Net/OpenStack/Swift.pm
@@ -20,6 +20,7 @@ has auth_url     => (is => 'rw', required => 1, default => sub { $ENV{OS_AUTH_UR
 has user         => (is => 'rw', required => 1, default => sub { $ENV{OS_USERNAME}    || '' });
 has password     => (is => 'rw', required => 1, default => sub { $ENV{OS_PASSWORD}    || '' });
 has tenant_name  => (is => 'rw', required => 1, default => sub { $ENV{OS_TENANT_NAME} || '' });
+has region       => (is => 'rw', required => 1, default => sub { $ENV{OS_REGION_NAME} || '' });
 has storage_url  => (is => 'rw');
 has token        => (is => 'rw');
 has agent_options => (is => 'rw', isa => 'HashRef', default => sub{+{ timeout => 10 }});
@@ -63,7 +64,7 @@ sub auth_keystone {
     );
     $ksclient->agent($self->agent);
     my $auth_token = $ksclient->auth();
-    my $endpoint = $ksclient->service_catalog_url_for(service_type=>'object-store', endpoint_type=>'publicURL');
+    my $endpoint = $ksclient->service_catalog_url_for(service_type=>'object-store', endpoint_type=>'publicURL', region=>$self->region);
     croak "Not found endpoint type 'object-store'" unless $endpoint;
     $self->token($auth_token);
     $self->storage_url($endpoint);
@@ -594,6 +595,7 @@ Net::OpenStack::Swift - Perl Bindings for the OpenStack Object Storage API, know
         user           => 'userid',
         password       => 'password',
         tenant_name    => 'project_id',
+        region         => 'REGION',
         # auth_version => '2.0', # by default
         # agent_options => +{
         #    timeout    => 10,

--- a/lib/Net/OpenStack/Swift/InnerKeystone.pm
+++ b/lib/Net/OpenStack/Swift/InnerKeystone.pm
@@ -43,15 +43,15 @@ sub service_catalog_url_for {
     my $args = $rule->validate(@_);
 
     my $found_endpoint;
-    foreach my $service_catelog ( @{ $self->service_catalog } ) {
+    LOOP: foreach my $service_catelog ( @{ $self->service_catalog } ) {
         if ( $args->{service_type} eq $service_catelog->{type} ) {
             foreach my $endpoint ( @{ $service_catelog->{endpoints} } ) {
                 if ( exists $endpoint->{ $args->{endpoint_type} } ) {
-                    $found_endpoint = $endpoint;
-
-                    # filtering match Region
-                    if ( $args->{region} and $args->{region} ne $endpoint->{region} ) {
-                        $found_endpoint = undef;
+                    # check if the region matches or if there is no prefered region
+                    if ( !$args->{region} or $args->{region} eq $endpoint->{region} ) {
+                        $found_endpoint = $endpoint;
+                        # we found it, stop searching
+                        last LOOP;
                     }
                 }
             }


### PR DESCRIPTION
A script of mine that relies on `Net::OpenStack::Swift` has suddenly stopped working. After some debugging I was able to track the issue down to the `service_catalog_url_for` method of `Net::OpenStack::Swift::InnerKeystone::V2_0`.

The problem is that my `serviceCatalog` contains multiple `endpoints` for the service type `object-store` and I have to select the right one based on the `region` parameter. Unfortunately `Net::OpenStack::Swift` selects the last endpoint.

This PR adds mechanism to select the right endpoint by passing the `region` parameter to `service_catalog_url_for`.