### PR TITLE
proper handling of V1 auth

### DIFF
--- a/lib/Net/OpenStack/Swift/InnerKeystone.pm
+++ b/lib/Net/OpenStack/Swift/InnerKeystone.pm
@@ -94,8 +94,7 @@ sub auth {
         ]
     );
     croak "authorization failed: " . $res->status_line unless $res->is_success;
-    my $body_params = from_json( $res->content );
-    my $url         = $body_params->{storage}->{ $self->tenant_name };
+    my $url = $res->header('X-Storage-Url');
     $self->auth_token( $res->header('X-Auth-Token') );
     $self->service_catalog(
         [


### PR DESCRIPTION
I've faced an issue while working on https://selectel.ru/en/services/cloud/storage/ 
They use OpenStack Swift API 1.0.
All the response of `auth` call is provided in headers, not in JSON.
According to https://www.swiftstack.com/docs/cookbooks/swift_usage/auth.html this is the correct behavior for version 1.0
So I've updated `auth` function for `V1_0`

Thanks!